### PR TITLE
Fixing jade version to 0.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "express": "3.1.0",
-    "jade": "*",
+    "jade": "0.35.0",
     "stylus": "*",
     "nib": "0.9.1"
   },


### PR DESCRIPTION
I tried to run the code and got errors for the jade template, mainly
- unexpected token "indent"
-  'doctype 5' is deprecated

I figured the app needs to be run on a previous version of Jade 
(ref: https://github.com/visionmedia/jade/blob/master/History.md)

Here I am updating package.json to fix the version of jade to 0.35.0. This fixes the problem.
